### PR TITLE
Use INTERCOM_API_KEY as Bearer token

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,6 @@ This app works by:
 * Set the following environment variables:
 
 ```
-# ID of your application in Intercom
-INTERCOM_APP_ID
-
 # API key for your Intercom account
 INTERCOM_API_KEY
 
@@ -53,4 +50,3 @@ APP_PASSWORD
   https://devcenter.heroku.com/articles/config-vars#setting-up-config-vars-for-a-deployed-application
 
 * In JIRA, set the webhook endpoint to `https://YOUR_APP_USERNAME:YOUR_APP_PASSWORD@your-app.herokuapp.com/jira_to_intercom`, where YOUR_APP_USERNAME is the value of the `APP_USERNAME` var, and YOUR_APP_PASSWORD is the value of the `APP_PASSWORD` var
-

--- a/app.json
+++ b/app.json
@@ -18,10 +18,6 @@
       "description": "Password used for basic auth",
       "generator": "secret"
     },
-    "INTERCOM_APP_ID": {
-      "description": "ID of your application in Intercom",
-      "value": "intercom_app_id"
-    },
     "INTERCOM_API_KEY": {
       "description": "API key for your Intercom account",
       "value": "intercom_api_key"

--- a/app.rb
+++ b/app.rb
@@ -3,7 +3,7 @@ Bundler.require
 Dir[File.dirname(__FILE__) + '/lib/*.rb'].each {|file| require file }
 
 INTERCOM_REGEX = /https:\/\/app.intercom.io\/a\/apps\/(?<app_id>\S*)\/inbox\/(\S*\/)?conversation(s)?\/(?<conversation_id>\d*)/
-INTERCOM_CLIENT = IntercomApiClient.new(ENV['INTERCOM_APP_ID'], ENV['INTERCOM_API_KEY'])
+INTERCOM_CLIENT = IntercomApiClient.new(ENV['INTERCOM_API_KEY'])
 JIRA_HOSTNAME = ENV['JIRA_HOSTNAME']
 
 use Rack::Auth::Basic, "Restricted Area" do |username, password|

--- a/lib/intercom_api_client.rb
+++ b/lib/intercom_api_client.rb
@@ -6,7 +6,7 @@ class IntercomApiClient
 
   attr_reader :default_params
 
-  def initialize(username, token)
+  def initialize(token)
     auth = "Bearer " + token
     @default_params = {
       :headers => {

--- a/lib/intercom_api_client.rb
+++ b/lib/intercom_api_client.rb
@@ -6,15 +6,13 @@ class IntercomApiClient
 
   attr_reader :default_params
 
-  def initialize(username, password)
+  def initialize(username, token)
+    auth = "Bearer " + token
     @default_params = {
-      :basic_auth => {
-        :username => username,
-        :password => password
-      },
       :headers => {
         'Accept'       => 'application/json',
-        'Content-Type' => 'application/json'
+        'Content-Type' => 'application/json',
+        "Authorization" => auth
       }
     }
   end


### PR DESCRIPTION
Remove usage of `INTERCOM_APP_ID` as `INTERCOM_API_KEY` is only needed.

With new Intercom API changes, Intercom API only needs
`INTERCOM_API_KEY` which is passed as `Bearer` token in headers.